### PR TITLE
Now passing the filename option to Babel (the typescript preset wanted it.)

### DIFF
--- a/src/main/java/com/jarslab/maven/babel/plugin/transpiler/BabelTranspiler.java
+++ b/src/main/java/com/jarslab/maven/babel/plugin/transpiler/BabelTranspiler.java
@@ -19,7 +19,8 @@ import static java.util.stream.Collectors.joining;
 public class BabelTranspiler implements AutoCloseable
 {
     private static final String INPUT_VARIABLE = "input";
-    private static final String BABEL_EXECUTE = "Babel.transform(%s, {presets: [%s], plugins: [%s]}).code";
+    private static final String FILENAME_VARIABLE = "filename";
+    private static final String BABEL_EXECUTE = "Babel.transform(%s, {filename: %s, presets: [%s], plugins: [%s]}).code";
 
     private TranspilationContext transpilationContext;
     private Context executionContext;
@@ -59,9 +60,11 @@ public class BabelTranspiler implements AutoCloseable
                     .collect(joining(lineSeparator()));
             final Value bindings = executionContext.getBindings("js");
             bindings.putMember(INPUT_VARIABLE, source);
+            bindings.putMember(FILENAME_VARIABLE, transpilation.getSource().toString());
             final String result = executionContext.eval("js", format(
                     BABEL_EXECUTE,
                     INPUT_VARIABLE,
+                    FILENAME_VARIABLE,
                     transpilationContext.getPresets(),
                     transpilationContext.getPlugins())).asString();
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
This is re. issue #17. Turns out, the plugin just wanted a filename.