### PR TITLE
An option to change the translated file's extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ or development version,
 * **`jsIncludes`** - list of JavaScript files (with simple masks `*`/`?`),
 * **`jsExcludes`** - list of exceptions for `jsIncludes`,
 * **`prefix`** - optional prefix applied for every translated file,
+* **`targetFileExtension`** - if specified, the extension of every translated file will be set to this string (e.g., `js`).
 * **`formatPresets`** - enable/disable presets formatting (default: _true_). Once disabled `presets` are required to be well formatted,  
 * **`presets`** - presets for Babel execution (default: _es2015_),
 * **`plugins`** - plugins for Babel execution (default: _""_ (empty)) _NOTE: any custom plugins are required to be available in provided `babelSrc`_

--- a/src/main/java/com/jarslab/maven/babel/plugin/BabelMojo.java
+++ b/src/main/java/com/jarslab/maven/babel/plugin/BabelMojo.java
@@ -47,6 +47,9 @@ public class BabelMojo extends AbstractMojo
 
     @Parameter(property = "prefix")
     private String prefix;
+    
+    @Parameter(property = "targetFileExtension")
+    private String targetFileExtension;
 
     @Parameter(property = "presets", defaultValue = "es2015")
     private String presets;
@@ -158,6 +161,10 @@ public class BabelMojo extends AbstractMojo
         return this.encoding;
     }
 
+    public String getTargetFileExtension() {
+		return targetFileExtension;
+	}
+
     public void setVerbose(boolean verbose)
     {
         this.verbose = verbose;
@@ -228,7 +235,11 @@ public class BabelMojo extends AbstractMojo
         this.encoding = encoding;
     }
 
-    @Override
+	public void setTargetFileExtension(String targetFileExtension) {
+		this.targetFileExtension = targetFileExtension;
+	}
+
+	@Override
     public String toString()
     {
         return "BabelMojo{" +
@@ -241,6 +252,7 @@ public class BabelMojo extends AbstractMojo
                 ", jsSourceIncludes=" + jsSourceIncludes +
                 ", jsSourceExcludes=" + jsSourceExcludes +
                 ", prefix='" + prefix + '\'' +
+                ", targetFileExtension='" + targetFileExtension + '\'' +
                 ", presets='" + presets + '\'' +
                 ", encoding='" + encoding + '\'' +
                 '}';

--- a/src/main/java/com/jarslab/maven/babel/plugin/TranspilationInitializer.java
+++ b/src/main/java/com/jarslab/maven/babel/plugin/TranspilationInitializer.java
@@ -94,7 +94,12 @@ class TranspilationInitializer
     {
         final Path relativePath = getRelativePath(sourceFile);
         final String prefix = babelMojo.getPrefix() == null ? "" : babelMojo.getPrefix();
-        return babelMojo.getTargetDir().toPath().resolve(relativePath).resolve(prefix + sourceFile.getFileName());
+        
+        String targetFileName = prefix + sourceFile.getFileName();
+        if (babelMojo.getTargetFileExtension() != null) 
+        	targetFileName = targetFileName.replaceFirst("\\.[^./]+$", "."+babelMojo.getTargetFileExtension());
+        
+		return babelMojo.getTargetDir().toPath().resolve(relativePath).resolve(targetFileName);
     }
 
     private String removeLeadingSlash(final String subject)


### PR DESCRIPTION
When transpiling a .ts, .jsx, or .tsx file, the resulting file's extension normally gets changed to .js (e.g., the input is in typescript, but the output is in plain javascript.) This plugin currently leaves the extension as is. I am proposing an option to set the translated files' extensions to a given string, e.g. "js".